### PR TITLE
テキストのタグの情報に応じてプレビューエリアの文字のマークアップを切り替える機能実装

### DIFF
--- a/app/assets/javascripts/admin/directives/description.js
+++ b/app/assets/javascripts/admin/directives/description.js
@@ -31,7 +31,7 @@ angular.module('UrbanOutdoorApp')
           if(html) {
           subHeadButton = '<button id="subHead" class="btn-info">見出しとして登録</button>';
           descriptionButton = '<button id="description" class="btn-info">説明文として登録</button>';            
-            element.html(html.replace(/[\n\r]/g, '<br />') + subHeadButton + descriptionButton);
+            element.html(subHeadButton + descriptionButton);
             $compile(element.contents())(scope);
           }
         });

--- a/app/assets/javascripts/admin/directives/preview-text.js
+++ b/app/assets/javascripts/admin/directives/preview-text.js
@@ -1,0 +1,27 @@
+'use strict';
+
+angular.module('UrbanOutdoorApp')
+  .directive('previewText', function($compile) {
+    var selectTemplate = function(tag){
+      var templateHTML;
+      if(tag === 'sub_head'){
+        templateHTML = '<h3>{{ contents }}</h3>';
+      } else {
+        templateHTML = '<h4>{{ contents }}</h4>';
+      }
+      return templateHTML;
+    };
+    return {
+      restrict: 'E',
+      scope: {
+        tag: '=tag',
+        contents: '=data'
+      },
+      link: function (scope, element, attrs) {
+        var template;
+        template = selectTemplate(scope.tag);
+        element.html(template);
+        $compile(element.contents())(scope);
+      }
+    };
+  });

--- a/app/views/admin/articles/new.html.erb
+++ b/app/views/admin/articles/new.html.erb
@@ -20,16 +20,14 @@
     <div class="row">
       <div class="col-xs-12 article__contents__preview">
         <h4>プレビューエリア</h4>
-        <div ng-if="mainTitle">{{ mainTitle }}</div>
+        <hr/>
+        <h2 ng-if="mainTitle">{{ mainTitle }}</h2>
         <div class="article__contents__container">
           <div ng-repeat="content in contentsArea track by $index">
-            <items data="content.element_data" ng-if="content.tag_name == 'items'"></items>
+            <preview-text data="content.element_data" tag="content.tag_name" ng-if="content.tag_name == 'sub_head' || content.tag_name == 'description'"></preview-text>
             <img class="article__contents__preview__thumb" ng-if="content.tag_name == 'img' || content.tag_name == 'thumbnail' || content.tag_name == 'title_img' || content.tag_name == 'subtitle_img' || content.tag_name == 'main_visual_image'" picture="content.imagePath"/>
-            <heading data="content.element_data" ng-if="content.tag_name == 'heading'"></heading>
-            <div ng-if="content.tag_name == 'sub_head'">{{content.element_data }}</div>
-            <div layout="content.element_data" ng-if="content.tag_name == 'hr'"></div>
+
             <instagram data="content.element_data" ng-if="content.tag_name == 'instagram'"></instagram>
-            <linkbutton data="content.element_data" ng-if="content.tag_name == 'linkbutton'"></linkbutton>
           </div>
         </div>
       </div>


### PR DESCRIPTION
issue #61 の対応
- sub_headのタグが付いた場合
  - H3のタグを付与
- descriptionのタグが付いた場合
  - H4のタグを付与

という形で最終的にこういう画面になるように修正

<img width="400" alt="screenshot 2016-02-17 18 15 23" src="https://cloud.githubusercontent.com/assets/950924/13104765/79d8481a-d5a2-11e5-9183-d203992ee5de.png">
